### PR TITLE
Add Plains & Prairies Pack DLC support and fix NEXAT Pack installation

### DIFF
--- a/run/nobody/setup_fs25.sh
+++ b/run/nobody/setup_fs25.sh
@@ -54,6 +54,13 @@ else
         echo -e "${YELLOW}WARNING: If you do not own it ignore this!${NOCOLOR}"
 fi
 
+if [ -f /opt/fs25/dlc/FarmingSimulator25_plainsAndPrairiesPack_*.exe ]; then
+    echo -e "${GREEN}INFO: Plains & Prairies Pack FOUND!${NOCOLOR}"
+else
+        echo -e "${YELLOW}WARNING: Plains & Prairies Pack not found, do you own it and does it exist in the dlc mount path?${NOCOLOR}"
+        echo -e "${YELLOW}WARNING: If you do not own it ignore this!${NOCOLOR}"
+fi
+
 # it's important to check if the config directory exists on the host mount path. If it doesn't exist, create it.
 
 if [ -d /opt/fs25/config/FarmingSimulator2025 ]
@@ -201,10 +208,21 @@ if [ -f ~/.fs25server/drive_c/users/nobody/Documents/My\ Games/FarmingSimulator2
 then
     echo -e "${GREEN}INFO: NEXAT Pack is already installed!${NOCOLOR}"
 else
-    if [ -f /opt/fs25/dlc/FarmingSimulator25_macDonPack_*.exe ]; then
+    if [ -f /opt/fs25/dlc/FarmingSimulator25_nexatPack_*.exe ]; then
         echo -e "${GREEN}INFO: Installing NEXAT Pack..!${NOCOLOR}"
-        for i in /opt/fs25/dlc/FarmingSimulator25_nexatPack_*.exe; do wine "$i"; done
+        for i in /opt/fs25/dlc/FarmingSimulator25_nexatPack*.exe; do wine "$i"; done
         echo -e "${GREEN}INFO: NEXAT Pack is now installed!${NOCOLOR}"
+    fi
+fi
+
+if [ -f ~/.fs25server/drive_c/users/nobody/Documents/My\ Games/FarmingSimulator2025/pdlc/plainsAndPrairiesPack.dlc ]
+then
+    echo -e "${GREEN}INFO: Plains & Prairies Pack is already installed!${NOCOLOR}"
+else
+    if [ -f /opt/fs25/dlc/FarmingSimulator25_plainsAndPrairiesPack_*.exe ]; then
+        echo -e "${GREEN}INFO: Installing Plains & Prairies Pack..!${NOCOLOR}"
+        for i in /opt/fs25/dlc/FarmingSimulator25_plainsAndPrairiesPack*.exe; do wine "$i"; done
+        echo -e "${GREEN}INFO: Plains & Prairies Pack is now installed!${NOCOLOR}"
     fi
 fi
 


### PR DESCRIPTION
Overview:
This PR enhances the DLC installation functionality by adding support for the Plains & Prairies Pack and fixing a bug in the NEXAT Pack installation logic.

Changes Made:

✨ New Feature: Plains & Prairies Pack Support

- Added detection for FarmingSimulator25_plainsAndPrairiesPack_*.exe installer files
- Implemented installation logic that checks for existing plainsAndPrairiesPack.dlc
- Added consistent messaging and error handling following the established pattern
- Supports the full version string format: FarmingSimulator25_plainsAndPrairiesPack_1_1_0_0_ESD.exe

🐛 Bug Fix: NEXAT Pack Installation

- Fixed critical bug: NEXAT Pack installation was incorrectly checking for macDonPack installer instead of nexatPack
- This bug prevented NEXAT Pack from being installed even when the installer was present
- Now correctly looks for FarmingSimulator25_nexatPack_*.exe files

> Note: This contribution was developed with assistance from AI tools
