### PR TITLE
Fix crossplay option on autostart server

### DIFF
--- a/run/nobody/start_game.mjs
+++ b/run/nobody/start_game.mjs
@@ -45,7 +45,7 @@ async function send_request(host, method, data = {}, session_cookie = '') {
   if (method === 'GET' && Object.keys(data).length > 0) {
     path += '&' + body;
   }
-  const agent = new http.Agent({keepAlive: false});
+  const agent = new http.Agent({ keepAlive: false });
   const options = {
     method,
     headers,
@@ -115,7 +115,7 @@ const expected_start_params = [
   'mp_language',
   'auto_save_interval',
   'stats_interval',
-  'pause_game_if_empty',
+  'pause_game_if_empty'
 ];
 
 function get_regex(text, regex) {
@@ -164,6 +164,10 @@ async function main() {
     params[key] = unsorted_params[key];
   }
   params['game_name'] = '+%2B+' + params['game_name'];
+
+  const crossplay_checked = /<input type="checkbox" name="crossplay_allowed" checked="checked"/.test(html);
+  params['crossplay_allowed'] = crossplay_checked ? 'on' : 'off';
+
   params['start_server'] = 'Start';
 
   console.log('Starting server');


### PR DESCRIPTION
<img width="1042" height="145" alt="Screenshot 2026-02-23 at 10 52 57" src="https://github.com/user-attachments/assets/2a918f91-365a-4174-aa18-9bb1d7aad4d3" />
This flag was not recognized on automatic server start-up, because it's `checkbox` HTML `input` element, not `select` HTML element. This fix appends configuration with value of this `checkbox` if it's checked, or not.